### PR TITLE
Fix comments about what color is being set

### DIFF
--- a/examples/ina260_neopixel_modes/ina260_neopixel_modes.ino
+++ b/examples/ina260_neopixel_modes/ina260_neopixel_modes.ino
@@ -57,7 +57,7 @@ void loop() {
 void rampPixelColors(void){
   pixels.setBrightness(25);
   for(int i=0;i<NUMPIXELS;i++){
-    pixels.setPixelColor(i, pixels.Color(255,0, 0)); // Moderately bright green color.
+    pixels.setPixelColor(i, pixels.Color(255,0, 0)); // Red
     pixels.show(); // This sends the updated pixel color to the hardware.
     Serial.print(ina260.readCurrent());
     Serial.print(" ");
@@ -70,7 +70,7 @@ void rampPixelColors(void){
 
   pixels.setBrightness(50);
   for(int i=0;i<NUMPIXELS;i++){
-    pixels.setPixelColor(i, pixels.Color(255,255, 0)); // Moderately bright green color.
+    pixels.setPixelColor(i, pixels.Color(255,255, 0)); // Yellow (Red + Green)
     pixels.show(); // This sends the updated pixel color to the hardware.
     Serial.print(ina260.readCurrent());
     Serial.print(" ");
@@ -83,7 +83,7 @@ void rampPixelColors(void){
 
   pixels.setBrightness(100);
   for(int i=0;i<NUMPIXELS;i++){
-    pixels.setPixelColor(i, pixels.Color(255,255, 255)); // Moderately bright green color.
+    pixels.setPixelColor(i, pixels.Color(255,255, 255)); // White (Red + Green + Blue)
     pixels.show(); // This sends the updated pixel color to the hardware.
     Serial.print(ina260.readCurrent());
     Serial.print(" ");


### PR DESCRIPTION
The calls to setPixelColor are all commented with
	// Moderately bright green color.
none of which are correct. While I might suggest other changes to this example,
at a minimum the comments shouldn't be wrong which might confuse some people.