### PR TITLE
Replaced deprecated boolean with bool

### DIFF
--- a/Adafruit_INA260.cpp
+++ b/Adafruit_INA260.cpp
@@ -49,7 +49,7 @@ Adafruit_INA260::Adafruit_INA260(void) {}
  *            The Wire object to be used for I2C connections.
  *    @return True if initialization was successful, otherwise false.
  */
-boolean Adafruit_INA260::begin(uint8_t i2c_address, TwoWire *theWire) {
+bool Adafruit_INA260::begin(uint8_t i2c_address, TwoWire *theWire) {
   i2c_dev = new Adafruit_I2CDevice(i2c_address, theWire);
 
   if (!i2c_dev->begin()) {

--- a/Adafruit_INA260.h
+++ b/Adafruit_INA260.h
@@ -90,8 +90,8 @@ typedef enum _count {
 class Adafruit_INA260 {
 public:
   Adafruit_INA260();
-  boolean begin(uint8_t i2c_addr = INA260_I2CADDR_DEFAULT,
-                TwoWire *theWire = &Wire);
+  bool begin(uint8_t i2c_addr = INA260_I2CADDR_DEFAULT,
+             TwoWire *theWire = &Wire);
   void reset(void);
   float readCurrent(void);
   float readBusVoltage(void);


### PR DESCRIPTION
Hi,

`boolean` type is deprecated in the official STM32 Arduino core, which causes some warnings when using this library. I replaced it with `bool` which should be supported by all the major Arduino cores, so it should be safe to use (and the library is already using it anyway).
