### PR TITLE
Extend library to add raw and int16 return values for voltage and current

### DIFF
--- a/Adafruit_INA260.cpp
+++ b/Adafruit_INA260.cpp
@@ -90,14 +90,55 @@ void Adafruit_INA260::reset(void) {
 }
 /**************************************************************************/
 /*!
+    @brief Reads integer ADC count of the current value of the Current register.
+    @return The unscaled current measurement count (mA/1.25)
+*/
+/**************************************************************************/
+int16_t Adafruit_INA260::readCurrentRaw(void) {
+  Adafruit_I2CRegister current =
+      Adafruit_I2CRegister(i2c_dev, INA260_REG_CURRENT, 2, MSBFIRST);
+  return (int16_t)current.read();
+ }
+/**************************************************************************/
+/*!
+    @brief Reads integer ADC count of the current value of the Current register.
+    @return The scaled current measurement in mA
+*/
+/**************************************************************************/
+int16_t Adafruit_INA260::readCurrentInt16(void) {
+  int16_t value = readCurrentRaw();
+  return value + (value >> 2);  // Multiply by 1.25
+ }
+/**************************************************************************/
+/*!
     @brief Reads and scales the current value of the Current register.
     @return The current current measurement in mA
 */
 /**************************************************************************/
 float Adafruit_INA260::readCurrent(void) {
-  Adafruit_I2CRegister current =
-      Adafruit_I2CRegister(i2c_dev, INA260_REG_CURRENT, 2, MSBFIRST);
-  return (int16_t)current.read() * 1.25;
+  int16_t value = readCurrentRaw();
+  return (float)value * 1.25;
+}
+/**************************************************************************/
+/*!
+    @brief Reads integer ADC count of the current value of the Bus Voltage register.
+    @return The unscaled bus voltage measurement count (mV/1.25)
+*/
+/**************************************************************************/
+int16_t Adafruit_INA260::readBusVoltageRaw(void) {
+  Adafruit_I2CRegister bus_voltage =
+      Adafruit_I2CRegister(i2c_dev, INA260_REG_BUSVOLTAGE, 2, MSBFIRST);
+  return (int16_t)bus_voltage.read();
+}
+/**************************************************************************/
+/*!
+    @brief Reads integer ADC count of the current value of the Bus Voltage register.
+    @return The scaled bus voltage measurement in mV
+*/
+/**************************************************************************/
+int16_t Adafruit_INA260::readBusVoltageInt16(void) {
+  int16_t value = readBusVoltageRaw();
+  return value + (value >> 2);  // Multiply by 1.25
 }
 /**************************************************************************/
 /*!
@@ -106,9 +147,8 @@ float Adafruit_INA260::readCurrent(void) {
 */
 /**************************************************************************/
 float Adafruit_INA260::readBusVoltage(void) {
-  Adafruit_I2CRegister bus_voltage =
-      Adafruit_I2CRegister(i2c_dev, INA260_REG_BUSVOLTAGE, 2, MSBFIRST);
-  return bus_voltage.read() * 1.25;
+  int16_t value = readBusVoltageRaw();
+  return (float)value * 1.25;
 }
 /**************************************************************************/
 /*!

--- a/Adafruit_INA260.h
+++ b/Adafruit_INA260.h
@@ -130,7 +130,11 @@ public:
              TwoWire *theWire = &Wire);
   void reset(void);
   float readCurrent(void);
+  int16_t readCurrentRaw(void);
+  int16_t readCurrentInt16(void);
   float readBusVoltage(void);
+  int16_t readBusVoltageRaw(void);
+  int16_t readBusVoltageInt16(void);
   float readPower(void);
   void setMode(INA260_MeasurementMode mode);
   INA260_MeasurementMode getMode(void);


### PR DESCRIPTION
The Adafruit_INA260 library returns floating point values for both bus voltage and current. Applications which want or need to avoid floating point values (for either performance or memory conservation) must directly query the INA260(s) through I2C; this takes the user's code out of the library and complicates development. The changes proposed in this pull request remedy this by providing four new very small functions and two modifications to existing functions:

- **Describe the scope of the proposed changes:**
  - int16_t readCurrentRaw(void): added, returns raw current ADC count with no scaling
  - int16_t readCurrentInt16(void): added, returns int16 scaled current ADC count
  - float readCurrent(void): modified, retrieves ADC count using readCurrentRaw()

  - int16_t readBusVoltageRaw(void): added, returns raw bus voltage ADC count with no scaling
  - int16_t readBusVoltageInt16(void): added, returns int16 scaled bus voltage ADC count
  - float readBusVoltage(void): modified, retrieves ADC count using readBusVoltageRaw()

- **Describe any known limitations with your change.**  There are no known limitations associated with the proposed changes, and the library is fully backward compatible.

- **Please run any tests or examples that can exercise your modified code.**  The proposed changes have been tested in a project published on GitHub [aicklen/psmonitor](https://github.com/aicklen/psmonitor).

These changes were prompted by the need to implement a calibration routine that is best handled using the raw values from the INA260.
